### PR TITLE
Update local-keys

### DIFF
--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -2,7 +2,9 @@
 {%- extends "ports.j2" %}
 {% block with_service_ports %}
 [config]
-local-keys=["authentication.fallback-admin", "cluster.node-id", "cluster.bind-addr", "cluster.bind-port", "directory.*", "jmap.*", "storage", "store.*", "tracer.*"]
+local-keys = [ "store.*", "directory.*", "tracer.*", "!server.blocked-ip.*", "!server.allowed-ip.*", "server.*",
+               "authentication.fallback-admin.*", "!cluster.key", "cluster.*",   "config.local-keys.*", 
+               "storage.data", "storage.blob", "storage.lookup", "storage.fts", "storage.directory", "certificate.*" ]
 
 [cluster]
 node-id={{ node_id }}


### PR DESCRIPTION
This changes the list of keys for which Stalwart considers the local config file to be the source of truth (as opposed to what is stored in the database).

The most significant part of this is the addition of `server.*` which includes the `server.http.allowed-endpoint` setting. A combination of setting this and later (once this PR is approved) deleting the setting from the database gets us to the state where JMAP works entirely but the web admin panel is inaccessible.