### PR TITLE
Change the namespace of allowed-endpoint setting

### DIFF
--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -5,7 +5,7 @@
 local-keys = [ "store.*", "directory.*", "tracer.*", "!server.blocked-ip.*", "!server.allowed-ip.*", "!server.hostname",
                "server.*", "authentication.fallback-admin.*", "!cluster.key", "cluster.*",   "config.local-keys.*",
                "jmap.*", "storage.data", "storage.blob", "storage.lookup", "storage.fts", "storage.directory",
-               "certificate.*" ]
+               "certificate.*", "http.allowed-endpoint" ]
 
 [cluster]
 node-id={{ node_id }}
@@ -102,7 +102,7 @@ secret="{{ fallback_admin_password }}"
 
 {% if jmap %}{{ jmap_toml }}{% endif -%}
 {%- if 'management' in node_services or 'https' in node_services -%}
-[server.http]
+[http]
 allowed-endpoint=[
 {%-   if 'management' in node_services %}
   "200"


### PR DESCRIPTION
Some detail on why this is necessary and fixes our admin panel access woes can be found in issue #74.