### PR TITLE
Update autoconfigs to include oauth2 config

### DIFF
--- a/pulumi/static-prod/thundermail.com.xml
+++ b/pulumi/static-prod/thundermail.com.xml
@@ -10,6 +10,13 @@
             <socketType>SSL</socketType>
             <username>%EMAILLOCALPART%@thunderbird.net</username>
             <authentication>password-cleartext</authentication>
+            <authentication>oauth2</authentication>
+            <oAuth2>
+              <issuer>https://auth.tb.pro/realms/tbpro</issuer>
+              <scope>openid offline_access</scope>
+              <authURL>https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth</authURL>
+              <tokenURL>https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token</tokenURL>
+            </oAuth2>
         </incomingServer>
         <outgoingServer type="smtp">
             <hostname>mail.thundermail.com</hostname>
@@ -17,6 +24,13 @@
             <socketType>SSL</socketType>
             <username>%EMAILLOCALPART%@thunderbird.net</username>
             <authentication>password-cleartext</authentication>
+            <authentication>oauth2</authentication>
+            <oAuth2>
+              <issuer>https://auth.tb.pro/realms/tbpro</issuer>
+              <scope>openid offline_access</scope>
+              <authURL>https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth</authURL>
+              <tokenURL>https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token</tokenURL>
+            </oAuth2>
         </outgoingServer>
     </emailProvider>
     <clientConfigUpdate url="https://autoconfig.thundermail.com/"></clientConfigUpdate>

--- a/pulumi/static-stage/stage-thundermail.com.xml
+++ b/pulumi/static-stage/stage-thundermail.com.xml
@@ -10,6 +10,13 @@
             <socketType>SSL</socketType>
             <username>%EMAILLOCALPART%@thunderbird.net</username>
             <authentication>password-cleartext</authentication>
+            <authentication>oauth2</authentication>
+            <oAuth2>
+              <issuer>https://auth-stage.tb.pro/realms/tbpro</issuer>
+              <scope>openid offline_access</scope>
+              <authURL>https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/auth</authURL>
+              <tokenURL>https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/token</tokenURL>
+            </oAuth2>
         </incomingServer>
         <outgoingServer type="smtp">
             <hostname>mail.stage-thundermail.com</hostname>
@@ -17,6 +24,13 @@
             <socketType>SSL</socketType>
             <username>%EMAILLOCALPART%@thunderbird.net</username>
             <authentication>password-cleartext</authentication>
+            <authentication>oauth2</authentication>
+            <oAuth2>
+              <issuer>https://auth-stage.tb.pro/realms/tbpro</issuer>
+              <scope>openid offline_access</scope>
+              <authURL>https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/auth</authURL>
+              <tokenURL>https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/token</tokenURL>
+            </oAuth2>
         </outgoingServer>
     </emailProvider>
     <clientConfigUpdate url="https://autoconfig.stage-thundermail.com/"></clientConfigUpdate>


### PR DESCRIPTION
This updates the Thundermail autoconfig files to include OAuth2 instructions. I have deployed this to stage (so I know the deployment works), but I am not certain how to test it.

Pertains to issue #56.