### PR TITLE
Allow accounts-stage peered connection traffic

### DIFF
--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -20,6 +20,9 @@ resources:
       enable_dns_hostnames: True
       endpoint_interfaces:
         - secretsmanager
+      additional_routes:
+        - destination_cidr_block: 10.11.0.0/16  # accounts-stage
+          vpc_peering_connection_id: pcx-0522c0f470450e165
 
   tb:elasticache:ElastiCacheReplicationGroup:
     stalwart:

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2>=3.1,<4.0
 pulumi_cloudflare==5.49.1
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.14
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@main
 toml>=0.10.2,<0.11


### PR DESCRIPTION
- Pertains to (but does not resolve) #78.
- Requires [this tb_pulumi PR](https://github.com/thunderbird/pulumi/pull/203).
- Requires [this accounts PR](https://github.com/thunderbird/thunderbird-accounts/pull/245).

There is a VPC peering connection set up on the Accounts side. It handles everything needed to enable communication between here and there except for the route table entry on this side to allow us to talk to their IPs.