### PR TITLE
Build a CI user per stack and give it admin access to the stack

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -173,4 +173,5 @@ def __sap_on_apply(resources):
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',
     project=project,
+    on_apply=__sap_on_apply,
 )


### PR DESCRIPTION
This is dependent upon [this PR](https://github.com/thunderbird/pulumi/pull/211).

This builds a new user per environment for CI which gets admin access only to its own stack.