### PR TITLE
Peer with fluentbit in stage, create private route to it

### DIFF
--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -30,10 +30,23 @@ resources:
        - eipalloc-0f512d7cb3929b176  # 63.179.185.6
       endpoint_interfaces:
         - secretsmanager
+      peering_connections:
+        fluentbit-stage:
+          peered_cidrs:
+            - 10.200.0.0/22
+          peer_vpc_id: vpc-0ca7a251bb806ebcd
+          auto_accept: True  # Requires both VPCs to be in same account and region
+          # Allow resolution of DNS records to private IPs (so we can use a private LB)
+          accepter:
+            allow_remote_vpc_dns_resolution: True
+          requester:
+            allow_remote_vpc_dns_resolution: True
       additional_routes:
         private:
           - destination_cidr_block: 10.11.0.0/16  # accounts-stage
             vpc_peering_connection_id: pcx-063f07eca0677a761
+          - destination_cidr_block: 10.200.0.0/22  # fluentbit-stage
+            vpc_peering_connection_id: pcx-0eaad64bcba492657
         public: []
 
   tb:ec2:SshableInstance:


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on [this PR](https://github.com/thunderbird/observability/pull/32).

This opens up pathways between the mailstrom-stage network and the fluentbit-stage network so that Stalwart can ship its metrics to Posthog via the fluentbit configuration in the middle. 

See: https://github.com/thunderbird/mailstrom/issues/92