### PR TITLE
Remove server setting exclusions

### DIFF
--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -2,9 +2,10 @@
 {%- extends "ports.j2" -%}
 {%- block with_service_ports -%}
 [config]
-local-keys = [ "store.*", "directory.*", "tracer.*", "!server.blocked-ip.*", "!server.allowed-ip.*", "!server.hostname",
-               "server.*", "authentication.fallback-admin.*", "!cluster.key", "cluster.*",   "config.local-keys.*",
-               "jmap.*", "storage.data", "storage.blob", "storage.lookup", "storage.fts", "storage.directory",
+local-keys = [ "store.*", "directory.*", "tracer.*", "server.listener.*",
+               "authentication.fallback-admin.*", "!cluster.key", "cluster.*",
+               "config.local-keys.*", "jmap.*", "storage.data", "storage.blob",
+               "storage.lookup", "storage.fts", "storage.directory",
                "http.allowed-endpoint", "http.allowed-endpoint.*" ]
 
 [cluster]


### PR DESCRIPTION
Ref: #175 

It's probably best if all special server settings are stored in the database rather than in the config file. The `local-keys` setting was set to `server.*`, meaning that all settings under the `server` namespace should be stored in this file. However, auto-ban and many other settings are in this domain, things we definitely want stored in the database.

This change reorganizes these settings a bit, keeping only `server.listener*` settings (open server ports) in the config file, offloading all other server settings to the database.

There is a remote chance that deploying this causes some settings to "reset". However, I suspect that's not really the case because we already have a few important ones excluded here and this file has not apparently been rewritten in Stage (I double-checked on the server there).

Applying this change enables issue #175 to proceed by enabling the change to be made in the web admin console.