### PR TITLE
Fix caldav integration test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
     "pytest==8.3.4",
     "locust==2.36.2",
     "jmapc==0.2.23",
-    "caldav==2.0.1",
+    "caldav==2.2.6",
     "pytz==2025.2",
     "vobject==0.9.9",
     "faker==38.2.0",


### PR DESCRIPTION
The CalDAV integration tests have been [failing in CI](https://github.com/thunderbird/mailstrom/actions/runs/22426071330) for awhile (nightly integration tests job that runs on Thundermail stage). The tests were passing fine locally but failing in CI; turns out upgrading the python caldav package used by the tests fixes the issue. Fixes #188 (more details there).

I ran the nightly integration tests job against this branch in CI and the [tests are now passing](https://github.com/thunderbird/mailstrom/actions/runs/22458927354).