### PR TITLE
Allow traffic from new celery container

### DIFF
--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -161,6 +161,7 @@ resources:
           source_security_group_ids:
             - sg-0a711c607f9e0b959  # accounts-stage api container
             - sg-02700bcc4c090da45  # accounts-stage celery container
+            - sg-0a4f6b81c40d63c1e  # accounts-stage new celery container
 
       spam_filter:
         bayes:


### PR DESCRIPTION
As part of the reclustering in Accounts, we must allow the new Celery container to speak to the Stalwart management API.