### PR TITLE
Fix failing JMAP integration tests

### DIFF
--- a/test/common/JMAP.py
+++ b/test/common/JMAP.py
@@ -23,6 +23,10 @@ from jmapc.methods import (
     MailboxGetResponse,
 )
 
+from common.const import (
+    TEST_MSG_SUBJECT_PREFIX,
+)
+
 
 class JMAP:
     def __init__(self, host, username, password, locust=False):
@@ -379,7 +383,7 @@ class JMAP:
         assert inbox_id, 'expected to get the inbox mailbox id'
 
         # our populate inbox has provided us with emails in the inbox
-        filter = EmailQueryFilterCondition(in_mailbox=inbox_id)
+        filter = EmailQueryFilterCondition(in_mailbox=inbox_id, text=TEST_MSG_SUBJECT_PREFIX)
 
         email_ids = self.query_email(filter)
 
@@ -582,7 +586,7 @@ class JMAP:
         Check the inbox for a message to arrive with the given subject. If the message hasn't arrived yet wait
         for it; return the id of the message after it has arrived (or -1 if it never arrived).
         """
-        max_checks = 18
+        max_checks = 60
         wait_seconds = 5
         arrived_msg_id = 0
 

--- a/test/integration/caldav/test_caldav_calendar.py
+++ b/test/integration/caldav/test_caldav_calendar.py
@@ -34,7 +34,6 @@ class TestCaldavCalendar:
         assert default_cal.url == exp_url, 'expected default calendar url to be correct'
 
         display_name = default_cal.get_display_name()
-        # note: this currently fails, pending issue #63 being resolved
         assert display_name == CALDAV_EXP_DEFAULT_CALENDAR_NAME, 'expected the default calendar name to be correct'
 
     def test_create_calendar(self, caldav):

--- a/test/integration/carddav/test_carddav_address_book.py
+++ b/test/integration/carddav/test_carddav_address_book.py
@@ -36,7 +36,6 @@ class TestCarddavAddressBook:
 
         assert default_ab is not None, 'expected to be able to find the default address book'
         assert quote(carddav.username) in default_ab['href'], 'expected default address book url to be correct'
-        # note: this currently fails, pending issue #63 being resolved
         assert default_ab['displayname'] == CARDDAV_EXP_DEFAULT_ADDRESS_BOOK_NAME, (
             'expected default address book name to be correct'
         )


### PR DESCRIPTION
Fixes #192. Two JMAP tests were failing because the test method to retrieve emails generated by the tests was missing the subject filter so all emails were being returned; and an email existed inside the test account that was not generated by the tests, which was retrieved and didn't have the expected data so the tests failed. This fix ensures when retrieving test emails the emails are filtered by subject to only retrieve the emails generated by the tests, and if any other emails exist in the test account they won't interfere with the tests.

Also some of the integration tests that send multiple emails are failing intermittently, I believe it's because when the test checks to ensure all of the emails arrived they aren't waiting long enough. The tests check every 5 seconds for the emails to have been received; increasing the maximum number of email checks before the tests fail.

With this change the JMAP tests are once again [passing in CI here](https://github.com/thunderbird/mailstrom/actions/runs/22691092011/job/65786500401), and locally too:

```
collected 43 items                                                                                                                                                                                     

jmap/test_jmap_connect.py::TestJMAPConnect::test_get_session PASSED
jmap/test_jmap_connect.py::TestJMAPConnect::test_echo PASSED
jmap/test_jmap_connect.py::TestJMAPConnect::test_get_account_id PASSED
jmap/test_jmap_connect.py::TestJMAPConnect::test_get_identity PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_all PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_inbox PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_drafts PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_limit PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_subject PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_body PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_body_not_found PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_from PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_from_not_found PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_to PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_before_date PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_before_date_not_found PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_after_date PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_query_email_filter_after_date_not_found PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_get_email_single PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_get_email_id_not_exist PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_get_email_multi PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_create_draft_email PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_send_email_plain_text PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_send_email_html PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_send_email_with_cc PASSED
jmap/test_jmap_email.py::TestJMAPEmail::test_send_email_with_bcc PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_mailbox_query_all PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_mailbox_query_all_limit_results PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_mailbox_query_all_include_total PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_mailbox_query_filter_name PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_get_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_get_all_mailboxes PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_create_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_create_one_sub_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_create_multi_sub_mailboxes PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_create_multi_level_mailboxes PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_subscribe_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_unsubscribe_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_rename_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_rename_sub_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_delete_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_delete_sub_mailbox PASSED
jmap/test_jmap_mailboxes.py::TestJMAPMailboxes::test_delete_mailbox_containing_child PASSED
```