### PR TITLE
Deny access to the old Celery container

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -161,8 +161,7 @@ resources:
           excluded_nodes: ["0", "1"]
           source_security_group_ids:
             - sg-034b36952ac31b87b  # accounts-prod api container
-            - sg-0e2628172e0d95cc3  # accounts-prod celery container
-            - sg-0ede6c1f9f8a4b676  # accounts-prod new celery container
+            - sg-0ede6c1f9f8a4b676  # accounts-prod celery container
 
       spam_filter:
         bayes:


### PR DESCRIPTION
Also no longer refer to the only running Celery container as the "new" one.

Ref: https://github.com/thunderbird/thunderbird-accounts/issues/621