### PR TITLE
Create sanity test to run against Thundermail stage

### DIFF
--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -47,8 +47,6 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install pytest
-          pip install pytz
           pip install ."[dev]"
 
       - name: JMAP integration tests

--- a/.github/workflows/sanity-test-stage.yml
+++ b/.github/workflows/sanity-test-stage.yml
@@ -1,22 +1,19 @@
-name: nightly-integration-tests
+name: sanity-test-stage
 
 concurrency:
-  group: nightly-integration-tests
+  group: sanity-test-stage
   cancel-in-progress: true
 
 on:
-  schedule:
-    # run every day at 2am UTC (9PM EST)
-    - cron:  '0 2 * * *'
-  # allows you to run this workflow manually from the Actions tab
+  # run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
   contents: read # required for actions checkout
 
 jobs:
-  nightly-integration-tests:
-    name: nightly-integration-tests
+  stage-sanity-test:
+    name: stage-sanity-test
     # github actions ubuntu runners have known intermittent network timeout / connection issues
     # (i.e. https://github.com/actions/runner-images/issues/11886) that cause the integration tests
     # to fail with intermittent connection reset issues; so we use macos runners instead
@@ -51,45 +48,13 @@ jobs:
           pip install pytz
           pip install ."[dev]"
 
-      - name: JMAP integration tests
+      - name: Run sanity test on stage
         continue-on-error: true # we want all tests to run even if these or others fail
         run: |
           source .venv/bin/activate
           cd test/integration
           cp .env.test.example .env.test
-          python -m pytest jmap/ --junit-xml=./jmap-test-results.xml -vs
-
-      - name: IMAP integration tests
-        continue-on-error: true # we want all tests to run even if these or others fail
-        run: |
-          source .venv/bin/activate
-          cd test/integration
-          cp .env.test.example .env.test
-          python -m pytest imap/ --junit-xml=./imap-test-results.xml -vs
-
-      - name: SMTP integration tests
-        continue-on-error: true # we want all tests to run even if these or others fail
-        run: |
-          source .venv/bin/activate
-          cd test/integration
-          cp .env.test.example .env.test
-          python -m pytest smtp/ --junit-xml=./smtp-test-results.xml -vs
-
-      - name: CalDAV integration tests
-        continue-on-error: true # we want all tests to run even if these or others fail
-        run: |
-          source .venv/bin/activate
-          cd test/integration
-          cp .env.test.example .env.test
-          python -m pytest caldav/ --junit-xml=./caldav-test-results.xml -vs
-
-      - name: CardDAV integration tests
-        continue-on-error: true # we want all tests to run even if these or others fail
-        run: |
-          source .venv/bin/activate
-          cd test/integration
-          cp .env.test.example .env.test
-          python -m pytest carddav/ --junit-xml=./carddav-test-results.xml -vs
+          python -m pytest -m sanity --junit-xml=./sanity-test-results.xml -vs
 
       - name: Create results report
         continue-on-error: true # we always want this step to run
@@ -99,4 +64,4 @@ jobs:
           path: test/integration/*test-results.xml
           summary: true
           fail-on-empty: false
-          title: Mailstrom Integration Test Results
+          title: Stage Sanity Test Results

--- a/.github/workflows/sanity-test-stage.yml
+++ b/.github/workflows/sanity-test-stage.yml
@@ -44,8 +44,6 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install pytest
-          pip install pytz
           pip install ."[dev]"
 
       - name: Run sanity test on stage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,11 @@ dev = [
     "vobject==0.9.9",
     "faker==38.2.0",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "sanity: marks tests as sanity tests",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ dependencies = { file = ["pulumi/requirements.txt"] }
 dev = [
     "ruff",
     "python-dotenv==1.0.1",
-    "pytest==8.3.4",
+    "pytest==9.0.3",
     "locust==2.36.2",
     "jmapc==0.2.23",
     "caldav==2.2.6",
-    "pytz==2025.2",
+    "pytz==2026.1",
     "vobject==0.9.9",
     "faker==38.2.0",
 ]

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,6 +1,6 @@
 # Mailstrom Integration Tests
 
-The purpose of the integration tests is to verify basic IMAP/SMTP/JMAP support on a running mailstrom instance.
+The purpose of the integration tests is to verify IMAP/SMTP/JMAP/CalDAV/CardDAV support on a running mailstrom instance.
 
 
 ## Installation
@@ -82,6 +82,13 @@ To run a single integration test (i.e. IMAP login):
 ```bash
 cd test/integration
 python -m pytest -vs imap/test_login.py
+```
+
+To run the 'sanity' test suite (a basic subset of the integration tests):
+
+```bash
+cd test/integration
+python -m pytest -m sanity -vs
 ```
 
 ### Enable debug logging

--- a/test/integration/caldav/test_caldav_calendar.py
+++ b/test/integration/caldav/test_caldav_calendar.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 
 from datetime import datetime
@@ -25,6 +26,7 @@ class TestCaldavCalendar:
         cals_returned = caldav.get_calendars()
         assert len(cals_returned) > 0, 'expected at least 1 calendar to have been returned'
 
+    @pytest.mark.sanity
     def test_get_default_calendar(self, caldav):
         # retrieve the default calendar and verify
         default_cal = caldav.get_default_calendar()
@@ -36,6 +38,7 @@ class TestCaldavCalendar:
         display_name = default_cal.get_display_name()
         assert display_name == CALDAV_EXP_DEFAULT_CALENDAR_NAME, 'expected the default calendar name to be correct'
 
+    @pytest.mark.sanity
     def test_create_calendar(self, caldav):
         # create a new calendar and verify
         cal_name = f'{CALENDAR_PREFIX} {datetime.now()}'

--- a/test/integration/caldav/test_caldav_events.py
+++ b/test/integration/caldav/test_caldav_events.py
@@ -128,7 +128,8 @@ class TestCaldavEvents:
         )
         assert found_event.component.get('dtend').dt == event_props['dtend'], 'expected event end time to be correct'
 
-    def test_edit_event(self, caldav, test_calendar):
+    @pytest.mark.sanity
+    def test_create_and_edit_event(self, caldav, test_calendar):
         # create an event in the test calendar then modify the event, verify
         # let's create an event that starts at 9am two days from now, and has a duration of 1 hour
         two_days_from_now = datetime.now(tz=self.tz_utc) + timedelta(days=2)
@@ -193,6 +194,7 @@ class TestCaldavEvents:
         found_event = caldav.get_event_by_uid(test_calendar, test_event.id)
         assert not found_event, 'expected event to not have been found after it was deleted'
 
+    @pytest.mark.sanity
     def test_get_all_events(self, caldav, test_calendar):
         # get all events from the test calendar (we know there is at least one event in the test calendar because
         # an event is added when the test calendar is created (via the test_calendar fixture in conftest.py)

--- a/test/integration/caldav/test_caldav_tasks.py
+++ b/test/integration/caldav/test_caldav_tasks.py
@@ -1,3 +1,4 @@
+import pytest
 import pytz
 import time
 
@@ -30,6 +31,7 @@ class TestCaldavTasks:
     tz_utc = pytz.timezone('UTC')  # use UTC so there's no daylight savings time interference
     now = datetime.now(tz=tz_utc).replace(second=0, microsecond=0)
 
+    @pytest.mark.sanity
     def test_create_task(self, caldav, test_calendar):
         # create a task in the test calendar and verify (the test calendar is automatically
         # created before the tests run (via the test_calendar fixture in conftest.py)
@@ -109,6 +111,7 @@ class TestCaldavTasks:
         assert updated_task.component.get('due').dt == new_due, 'expected task due datetime to have been modified'
         assert updated_task.component.get('description') == new_desc, 'expected new task desc'
 
+    @pytest.mark.sanity
     def test_mark_task_completed(self, caldav, test_calendar):
         # create a task and mark it completed, verify
         one_day_from_now = self.now + timedelta(days=1)
@@ -223,6 +226,7 @@ class TestCaldavTasks:
         assert first_task.id in completed_tasks_ids, 'expected the first task to be found in completed tasks list'
         assert second_task.id not in completed_tasks_ids, 'expected the second task not to be found in completed tasks'
 
+    @pytest.mark.sanity
     def test_get_all_tasks(self, caldav, test_calendar):
         # retrieve all existing tasks; we know that at least one task already exists because one is created
         # in our test calendar automatically at the test suite start (see test_calendar in conftest.py)

--- a/test/integration/carddav/test_carddav_address_book.py
+++ b/test/integration/carddav/test_carddav_address_book.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from datetime import datetime
 from urllib.parse import quote
@@ -25,6 +26,7 @@ class TestCarddavAddressBook:
         abs_returned = carddav.get_address_books()
         assert len(abs_returned) > 0, 'expected at least 1 address book to exist'
 
+    @pytest.mark.sanity
     def test_get_default_address_book(self, carddav):
         # retrieve the default address book and verify
         default_ab = None
@@ -41,6 +43,7 @@ class TestCarddavAddressBook:
         )
         return
 
+    @pytest.mark.sanity
     def test_create_address_book(self, carddav):
         # create a new address book and verify
         ab_name = f'{ADDRESS_BOOK_PREFIX} {datetime.now()}'

--- a/test/integration/carddav/test_carddav_contacts.py
+++ b/test/integration/carddav/test_carddav_contacts.py
@@ -119,12 +119,14 @@ class TestCarddavContacts:
         if contact_details.get('note'):
             assert found_vcard.note.value == contact_details['note'], 'expected note to be correct'
 
+    @pytest.mark.sanity
     def test_get_contacts_list(self, carddav, test_address_book):
         # retrieve a list of all of the contacts that exist in our test address book; we know there
         # is at least one because when our test address book was created one contact was added
         all_contacts = carddav.get_all_contacts(test_address_book['href'])
         assert all_contacts is not None, 'expected at least one contact to be found'
 
+    @pytest.mark.sanity
     def test_update_contact(self, carddav, test_address_book):
         # edit an existing contact and verify changes were saved; we know at least one contact already
         # exists in our test address book that was created at the test start by our conftest.py fixture

--- a/test/integration/imap/test_mailboxes.py
+++ b/test/integration/imap/test_mailboxes.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 
 from common.logger import log
 from common.utils import convert_raw_mailbox_list
@@ -37,6 +38,7 @@ class TestIMAPMailboxes:
         for expected_mailbox in DEFAULT_IMAP_MAILBOX_LIST:
             assert expected_mailbox in mailbox_list, 'expected default mailboxes to exist'
 
+    @pytest.mark.sanity
     def test_create_mailbox(self, imap):
         # create and subscribe to unique mailbox
         name = f'{MAILBOX_PREFIX} {datetime.datetime.now()}'
@@ -100,6 +102,7 @@ class TestIMAPMailboxes:
         assert result == RESULT_NO, 'expected status of NO when attempt to create mailbox that already exists'
         assert MISSING_ARGS in data[0], 'expected missing arguments message'
 
+    @pytest.mark.sanity
     def test_subscribe_mailbox(self, imap):
         new_mailbox = f'{MAILBOX_PREFIX} {datetime.datetime.now()}'
         imap.create_mailbox(new_mailbox)

--- a/test/integration/imap/test_messaging.py
+++ b/test/integration/imap/test_messaging.py
@@ -168,6 +168,7 @@ class TestIMAPMessaging:
         found_msgs = imap.search_messages('ON 01-Jan-2025')
         assert len(found_msgs) == 0, 'expected to find 0 messages'
 
+    @pytest.mark.sanity
     def test_mark_message_read(self, imap):
         # we need an unread message to start; select one of our existing inbox test messages
         imap.select_mailbox()
@@ -310,6 +311,7 @@ class TestIMAPMessaging:
         found_msg = imap.search_messages('SUBJECT', msg_subject)
         assert len(found_msg) == 0, 'expected NOT to find the deleted message after calling expunge'
 
+    @pytest.mark.sanity
     def test_fetch_message_details(self, imap):
         # fetch message details from a test message in the test_acct_1 inbox
         imap.select_mailbox()

--- a/test/integration/jmap/test_jmap_email.py
+++ b/test/integration/jmap/test_jmap_email.py
@@ -23,6 +23,7 @@ class TestJMAPEmail:
         email_ids = jmap_acct_1.query_email()
         assert len(email_ids) >= 1, 'expected at least 1 email id to be returned'
 
+    @pytest.mark.sanity
     def test_query_email_inbox(self, jmap_acct_1):
         # our populate inbox fixture ensures that email already exists in our TEST_ACCT_1 inbox, so query
         # for all email in the inbox
@@ -175,6 +176,7 @@ class TestJMAPEmail:
         email_ids = jmap_acct_1.query_email(filter)
         assert len(email_ids) == 0, 'expected zero email ids to be returned'
 
+    @pytest.mark.sanity
     def test_get_email_single(self, jmap_acct_1):
         # our populate inbox fixture ensures that an email already exists in our TEST_ACCT_1 inbox
         # query to get email ids from the inbox and then retrieve one of the actual emails
@@ -269,6 +271,7 @@ class TestJMAPEmail:
         msg_arrived = jmap_acct_1.wait_for_message_to_arrive(subject)
         assert msg_arrived, f'expected the sent message to have arrived at {TEST_ACCT_1_EMAIL.split("@")[0]}'
 
+    @pytest.mark.sanity
     def test_send_email_html(self, jmap_acct_1, jmap_acct_2):
         # send an email with html body content
         subject = f'{TEST_MSG_SUBJECT_PREFIX} JMAP send HTML test {datetime.now()}'

--- a/test/integration/jmap/test_jmap_mailboxes.py
+++ b/test/integration/jmap/test_jmap_mailboxes.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 
 from common.logger import log
 from jmapc import MailboxQueryFilterCondition
@@ -74,6 +75,7 @@ class TestJMAPMailboxes:
         assert inbox_details.total_threads >= 0, 'expected mailbox total threads to be >= 0'
         assert inbox_details.unread_threads >= 0, 'expected mailbox unread threads to be >= 0'
 
+    @pytest.mark.sanity
     def test_get_all_mailboxes(self, jmap_acct_1):
         # get mailbox details for all mailboxes
         results = jmap_acct_1.get_mailboxes_by_id()
@@ -99,6 +101,7 @@ class TestJMAPMailboxes:
             assert exp_mailbox in found_mailboxes, f'expected mailbox to exist with details: {exp_mailbox}'
             log.debug(f"found mailbox '{exp_mailbox['name']}'")
 
+    @pytest.mark.sanity
     def test_create_mailbox(self, jmap_acct_1):
         # create a new mailbox at root level and verify it exists
         name = f'{MAILBOX_PREFIX} {datetime.datetime.now()}'
@@ -171,6 +174,7 @@ class TestJMAPMailboxes:
             assert found, 'expected new sub-mailbox to exist'
             assert found[0].parent_id == sub_mailbox['parent_id'], 'expected the sub-mailbox parent id to be correct'
 
+    @pytest.mark.sanity
     def test_subscribe_mailbox(self, jmap_acct_1):
         # create a new (unsubscribed) mailbox then subscribe to it after it was created
         name = f'{MAILBOX_PREFIX} {datetime.datetime.now()}'

--- a/test/integration/smtp/test_smtp_messaging.py
+++ b/test/integration/smtp/test_smtp_messaging.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import pytest
 
 from common.logger import log
 
@@ -135,6 +136,7 @@ class TestSMTPMessaging:
         assert send_exception, 'expected send message to fail'
         assert 'SMTPRecipientsRefused' in send_exception, 'expected correct exception type'
 
+    @pytest.mark.sanity
     def test_send_email_html(self, smtp, imap):
         subject = f'{TEST_MSG_SUBJECT_PREFIX} SMTP send test html {datetime.datetime.now()}'
         send_exception = smtp.send_test_email_multipart(


### PR DESCRIPTION
Create a `sanity test` which is a subset of the existing integration tests that will validate the very basic functionality of JMAP/IMAP/SMTP/CalDAV/Cardav on Thundermail stage. Have the ability to run the new sanity test against Thundermail stage by triggering it manually via a Github Actions workflow. Fixes #205.