### PR TITLE
Break peering to observability VPCs

### DIFF
--- a/pulumi/config.dev.yaml
+++ b/pulumi/config.dev.yaml
@@ -35,24 +35,12 @@ resources:
       enable_dns_hostnames: True
       enable_nat_gateway: True
       egress_via_nat_gateway: True
-      peering_connections:
-        fluentbit-dev:
-          peered_cidrs:
-            - 10.202.0.0/22
-          peer_vpc_id: vpc-09d12278743f0da97
-          auto_accept: True  # Requires both VPCs to be in same account and region
-          # Allow resolution of DNS records to private IPs (so we can use a private LB)
-          accepter:
-            allow_remote_vpc_dns_resolution: True
-          requester:
-            allow_remote_vpc_dns_resolution: True
+      peering_connections: {}
       # If you want to supply specific EIPs to this, you can do that here:
       # nat_gateway_allocation_id: 
       # nat_gateway_secondary_allocation_ids:
       additional_routes:
-        private:
-          - destination_cidr_block: 10.202.0.0/22  # observability-dev
-            vpc_peering_connection_id: pcx-04d7e54008cd9326c
+        private: []
         public: []
       endpoint_interfaces:
         - secretsmanager

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -41,23 +41,11 @@ resources:
         - eipalloc-0055539e4d56176f1  # 5.60.96.11
       endpoint_interfaces:
         - secretsmanager
-      peering_connections:
-        fluentbit-prod:
-          peered_cidrs:
-            - 10.200.0.0/22
-          peer_vpc_id: vpc-028ee60c9e7f6b28e
-          auto_accept: True  # Requires both VPCs to be in same account and region
-          # Allow resolution of DNS records to private IPs (so we can use a private LB)
-          accepter:
-            allow_remote_vpc_dns_resolution: True
-          requester:
-            allow_remote_vpc_dns_resolution: True
+      peering_connections: {}
       additional_routes:
         private:
           - destination_cidr_block: 10.10.0.0/16  # accounts-prod
             vpc_peering_connection_id: pcx-0fdcc9b776a069d2d
-          - destination_cidr_block: 10.200.0.0/22  # fluentbit-prod
-            vpc_peering_connection_id: pcx-0d581e66566a6e00b
         public: []
 
       # Dynamic values set in code, or not at all:
@@ -69,7 +57,7 @@ resources:
     bastion:
       ssh_keypair_name: mailstrom-prod
       source_cidrs:
-        - 38.15.46.29/32
+        - 10.0.0.0/16
   # Fill out this template to build an SSH bastion
   # tb:ec2:SshableInstance:
   #   bastion:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -39,30 +39,18 @@ resources:
        - eipalloc-0f512d7cb3929b176  # 63.179.185.6
       endpoint_interfaces:
         - secretsmanager
-      peering_connections:
-        fluentbit-stage:
-          peered_cidrs:
-            - 10.201.0.0/22
-          peer_vpc_id: vpc-0c83219ee10024f16
-          auto_accept: True  # Requires both VPCs to be in same account and region
-          # Allow resolution of DNS records to private IPs (so we can use a private LB)
-          accepter:
-            allow_remote_vpc_dns_resolution: True
-          requester:
-            allow_remote_vpc_dns_resolution: True
+      peering_connections: {}
       additional_routes:
         private:
           - destination_cidr_block: 10.11.0.0/16  # accounts-stage
             vpc_peering_connection_id: pcx-063f07eca0677a761
-          - destination_cidr_block: 10.201.0.0/22  # fluentbit-stage
-            vpc_peering_connection_id: pcx-03dd1daa0b700ab37
         public: []
 
   tb:ec2:SshableInstance:
     bastion:
       ssh_keypair_name: mailstrom-stage
       source_cidrs:
-        - 10.2.0.0/16
+        - 10.1.0.0/16
       ami: ami-082478ca34e882109
 
   # Fill out this template to build an SSH bastion


### PR DESCRIPTION
As per [Observability #50](https://github.com/thunderbird/observability/issues/50), we no longer need the fluent-bit cluster running for Posthog events. Thus, alongside the [PR to destroy those resources](https://github.com/thunderbird/observability/pull/52) comes this PR, in which we destroy the VPC peering connections to the observability VPCs. They are no longer needed, since we are no longer piping data through these routes.