### PR TITLE
Create sanity test to run against Thundermail production

### DIFF
--- a/.github/workflows/sanity-test-prod.yaml
+++ b/.github/workflows/sanity-test-prod.yaml
@@ -1,0 +1,65 @@
+name: sanity-test-prod
+
+concurrency:
+  group: sanity-test-prod
+  cancel-in-progress: true
+
+on:
+  # run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read # required for actions checkout
+
+jobs:
+  prod-sanity-test:
+    name: prod-sanity-test
+    # github actions ubuntu runners have known intermittent network timeout / connection issues
+    # (i.e. https://github.com/actions/runner-images/issues/11886) that cause the integration tests
+    # to fail with intermittent connection reset issues; so we use macos runners instead
+    runs-on: macos-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      IS_CI_AUTOMATION: "yes"
+      TEST_SERVER_HOST: ${{ secrets.TEST_SERVER_HOST }}
+      TEST_ACCT_1_USERNAME: ${{ secrets.TEST_ACCT_1_USERNAME }}
+      TEST_ACCT_1_PASSWORD: ${{ secrets.TEST_ACCT_1_PASSWORD }}
+      TEST_ACCT_1_EMAIL: ${{ secrets.TEST_ACCT_1_EMAIL }}
+      TEST_ACCT_2_USERNAME: ${{ secrets.TEST_ACCT_2_USERNAME }}
+      TEST_ACCT_2_PASSWORD: ${{ secrets.TEST_ACCT_2_PASSWORD }}
+      TEST_ACCT_2_EMAIL: ${{ secrets.TEST_ACCT_2_EMAIL }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13.0'
+
+      - name: Install test dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install ."[dev]"
+
+      - name: Run sanity test on production
+        continue-on-error: true # we want all tests to run even if these or others fail
+        run: |
+          source .venv/bin/activate
+          cd test/integration
+          cp .env.test.example .env.test
+          python -m pytest -m sanity --junit-xml=./sanity-test-results.xml -vs
+
+      - name: Create results report
+        continue-on-error: true # we always want this step to run
+        if: always()
+        uses: pmeier/pytest-results-action@main
+        with:
+          path: test/integration/*test-results.xml
+          summary: true
+          fail-on-empty: false
+          title: Production Sanity Test Results

--- a/test/integration/caldav/test_caldav_calendar.py
+++ b/test/integration/caldav/test_caldav_calendar.py
@@ -36,7 +36,7 @@ class TestCaldavCalendar:
         assert default_cal.url == exp_url, 'expected default calendar url to be correct'
 
         display_name = default_cal.get_display_name()
-        assert display_name == CALDAV_EXP_DEFAULT_CALENDAR_NAME, 'expected the default calendar name to be correct'
+        assert CALDAV_EXP_DEFAULT_CALENDAR_NAME in display_name, 'expected the default calendar name to be correct'
 
     @pytest.mark.sanity
     def test_create_calendar(self, caldav):

--- a/test/integration/carddav/test_carddav_address_book.py
+++ b/test/integration/carddav/test_carddav_address_book.py
@@ -38,10 +38,9 @@ class TestCarddavAddressBook:
 
         assert default_ab is not None, 'expected to be able to find the default address book'
         assert quote(carddav.username) in default_ab['href'], 'expected default address book url to be correct'
-        assert default_ab['displayname'] == CARDDAV_EXP_DEFAULT_ADDRESS_BOOK_NAME, (
+        assert CARDDAV_EXP_DEFAULT_ADDRESS_BOOK_NAME in default_ab['displayname'], (
             'expected default address book name to be correct'
         )
-        return
 
     @pytest.mark.sanity
     def test_create_address_book(self, carddav):


### PR DESCRIPTION
In #216 I created a mailstrom `sanity test` that runs against Thundermail stage (a basic check of JMAP/IMAP/SMTP/CalDAV/CardDAV to be performed after Thundermail deployments). Now make the same sanity test for production. Allow the test to be triggered manually via GHA. Fixes #206.

Also a small fix to two of the tests.