### PR TITLE
fix(stalwart): allowlist CalDAV scheduling RSVP path (/calendar/rsvp)

### DIFF
--- a/pulumi/stalwart/__init__.py
+++ b/pulumi/stalwart/__init__.py
@@ -26,7 +26,7 @@ from stalwart import (
 
 #: Mapping of features of the https service and the API paths to enable for them
 HTTPS_FEATURES = {
-    'caldav': '/dav/cal,/dav/pal,/.well-known/caldav',
+    'caldav': '/dav/cal,/dav/pal,/.well-known/caldav,/calendar/rsvp',
     'carddav': '/dav/card,/dav/pal,/.well-known/carddav',
     'jmap': '/jmap,/.well-known/jmap',
     'webdav': '/dav/files,/dav/pal',

--- a/test/integration/caldav/test_caldav_rsvp.py
+++ b/test/integration/caldav/test_caldav_rsvp.py
@@ -1,0 +1,28 @@
+import pytest
+import requests
+
+from const import (
+    TEST_CALDAV_RSVP_URL,
+    CONNECT_TIMEOUT,
+)
+
+
+class TestCaldavRsvp:
+    @pytest.mark.sanity
+    def test_rsvp_endpoint_is_allowlisted(self):
+        """The CalDAV scheduling RSVP page (/calendar/rsvp) must be reachable.
+
+        Stalwart's ``http.allowed-endpoint`` rule is a deny-by-default allowlist built from the
+        cluster's enabled ``https_features``. If ``/calendar/rsvp`` is missing from that allowlist,
+        Stalwart returns 404 for the "Yes/No/Maybe" links in calendar invitation emails (see
+        thunderbird/mailstrom#223). This guards against that regression.
+
+        The endpoint is anonymous, so no credentials are needed. A bare GET (without the ``?i=``
+        token) still proves the path is allowlisted: the regression signal is specifically a 404
+        from the allowlist gate, so any non-404 status passes.
+        """
+        resp = requests.get(TEST_CALDAV_RSVP_URL, timeout=CONNECT_TIMEOUT)
+        assert resp.status_code != 404, (
+            f'{TEST_CALDAV_RSVP_URL} returned 404 — /calendar/rsvp is not allowlisted in Stalwart '
+            f'http.allowed-endpoint (got {resp.status_code}); calendar invitation RSVP links will break'
+        )

--- a/test/integration/const.py
+++ b/test/integration/const.py
@@ -24,6 +24,9 @@ JMAP_CAPABILITY_CORE_MAX_CALLS_IN_REQUEST = 16
 TEST_CALDAV_URL = f'https://{TEST_SERVER_HOST}/dav/cal'
 CALDAV_EXP_DEFAULT_CALENDAR_NAME = 'Thundermail Calendar'
 
+# CalDAV scheduling RSVP web endpoint (anonymous; served by Stalwart for iMIP "Yes/No/Maybe" links)
+TEST_CALDAV_RSVP_URL = f'https://{TEST_SERVER_HOST}/calendar/rsvp'
+
 # CardDAV
 TEST_CARDDAV_URL = f'https://{TEST_SERVER_HOST}/dav/card'
 CARDDAV_EXP_DEFAULT_ADDRESS_BOOK_NAME = 'Thundermail Address Book'


### PR DESCRIPTION
## Summary

Calendar invitation emails generated by Stalwart include HTTP RSVP (Yes / No / Maybe) links served at `/calendar/rsvp`. Clicking one returned a Stalwart `404` (`{"type":"about:blank","title":"Not Found","status":404,"detail":"Not Found"}`).

## Root cause

The public `https` listener's `[http] allowed-endpoint` rule (rendered in `pulumi/bootstrap/templates/stalwart.toml.j2`) is a **deny-by-default allowlist** built from `HTTPS_FEATURES` in `pulumi/stalwart/__init__.py`. Paths are matched with `starts_with(url_path, ...)`; anything not matched falls through to `{else="404"}`.

`/calendar/rsvp` was not part of any feature's path list, so Stalwart rejected it before serving the RSVP page. The request already reaches Stalwart — the load balancer is an L4 NLB and TLS terminates on the node — so this is purely an in-process allowlist gap, not an infrastructure routing issue.

## Change

Add `/calendar/rsvp` to the `caldav` feature:

```diff
 HTTPS_FEATURES = {
-    'caldav': '/dav/cal,/dav/pal,/.well-known/caldav',
+    'caldav': '/dav/cal,/dav/pal,/.well-known/caldav,/calendar/rsvp',
     'carddav': '/dav/card,/dav/pal,/.well-known/carddav',
     'jmap': '/jmap,/.well-known/jmap',
     'webdav': '/dav/files,/dav/pal',
 }
```

- The new prefix flows through the existing pipeline (`https_paths` tag → `bootstrap.py` → `stalwart.toml.j2` allowlist), producing `{if="starts_with(url_path, '/calendar/rsvp')",then="200"}`.
- No `config.{dev,stage,prod}.yaml` edits needed — all environments already enable `caldav`.
- No load balancer changes needed. Scoped to `/calendar/rsvp` (not `/calendar`) to avoid exposing other handlers.
- Server-side scheduling and the RSVP web feature are both preserved.

Also adds a credential-free sanity test (`test/integration/caldav/test_caldav_rsvp.py`, `@pytest.mark.sanity`) asserting `/calendar/rsvp` returns non-404.

---

## ✅ Deployed & verified on stage AND prod

| Check | stage | prod |
|-------|-------|------|
| `pulumi up` (tag-only on mail nodes, non-destructive) | ✅ | ✅ |
| `/calendar/rsvp` (was 404) | **200** | **200** |
| `/.well-known/caldav` (regression) | 307 | 307 |
| `/dav/cal` (regression) | 401 | 401 |
| bogus path (deny-by-default) | 404 | 404 |
| both `https` targets healthy | ✅ (1 node) | ✅ (2 nodes) |

Rollout per env: `pulumi up` (updates the `postboot.stalwart.https_paths` tag) → on each `https` node re-run `bootstrap.py` (regenerates `config.toml`; verified the `starts_with(url_path,'/calendar/rsvp')` rule rendered) → `systemctl daemon-reload && systemctl restart thundermail`. Prod done one node at a time, verifying target-group health between.

**Note:** the prod `pulumi up` replaced the SSH **bastion** (`SshableInstance` isn't AMI/user-data-pinned like the Stalwart nodes). No mail impact — the Stalwart mail nodes were tag-only updates and were not replaced. Possible follow-up: pin the bastion AMI to avoid recycling on future `pulumi up`s.

---

# Test plan

**Change under test:** `/calendar/rsvp` added to `HTTPS_FEATURES['caldav']`, rendering `{if="starts_with(url_path, '/calendar/rsvp')",then="200"}` into Stalwart's `[http] allowed-endpoint` allowlist.

> **DNS / Cloudflare:** stage/prod `mail.*` are **DNS-only** (CNAME → AWS NLB); Cloudflare is not in the HTTP path, so no edge cache/WAF considerations. (Only `mail.dev-thundermail.com` is proxied, and dev doesn't expose `https`.)

> **Rollout:** this change only updates the `postboot.stalwart.https_paths` EC2 **tag** — it does not change user data. Per `README.md:515-518`, a tag change after initial bootstrapping does not auto-apply to the running service, and (per `README.md:296-298`) user data only runs on first launch (a reboot/stop-start does **not** re-apply). So: `pulumi up` → re-run `bootstrap.py` on each `https` node → restart `thundermail`. `ignore_user_data_changes: True` is not a factor here (it only matters when second-stage bootstrap code/templates change).

### Results

- [x] **Baseline:** `/calendar/rsvp` → 404 (Stalwart `application/problem+json`) on stage & prod pre-fix.
- [x] **stage:** `pulumi up` (`~2 updated, 0 deleted`); node refresh; `/calendar/rsvp` 404 → **200**; regressions clean.
- [x] **prod:** `pulumi up` (`+0 -0 ~10`, succeeded); nodes 0 & 1 refreshed one at a time (both healthy); `/calendar/rsvp` **200** (6/6); regressions clean.
- [x] **Sanity test** added (`test/integration/caldav/test_caldav_rsvp.py`); runs in the `sanity-test-stage`/`sanity-test-prod` workflows.
- [ ] **End-to-end (manual):** send a real invite between two accounts, click Yes/No/Maybe, confirm the organizer's event `PARTSTAT` updates. *(Cosmetic: the RSVP page's logo image may show broken under OSS Stalwart — logo is served at `/logo`, Enterprise-only; not a regression.)*

### Notes / tracked follow-ups

- Consider shortening `calendar.scheduling.http-rsvp.expiry` from the 90-day default (anonymous-link replay window).
- The only anonymous rate-limit is JMAP-scoped; consider one covering `/calendar/rsvp`.
- Consider pinning the bastion AMI so `pulumi up` doesn't recycle it.
- The duplicate-events-in-Apple-Calendar symptom from #223 is a separate client-side issue, out of scope.

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
