### PR TITLE
Fix intermittent integration test failures

### DIFF
--- a/test/common/IMAP.py
+++ b/test/common/IMAP.py
@@ -379,12 +379,15 @@ class IMAP:
         """
         Mark the given message(s) as deleted (in the currently selected mailbox).
         """
+        if isinstance(msg_ids, str):
+            msg_ids = [msg_ids]
         for msg in msg_ids:
             log.debug(f'marking message {msg} as deleted')
             result, data = self.connection.store(msg, '+FLAGS', '\\Deleted')
             log.debug(f'{result}, {data}')
             assert result == RESULT_OK, 'expected to be able to mark message as deleted'
-            assert MSG_DELETED_FLAG in data[0], 'expected deleted flag to have been added'
+            msg_flags = self.fetch_message_flags(msg)
+            assert MSG_DELETED_FLAG in msg_flags[0], 'expected deleted flag to have been added'
 
     def permanently_delete_msgs(self):
         """

--- a/test/common/JMAP.py
+++ b/test/common/JMAP.py
@@ -351,17 +351,17 @@ class JMAP:
             log.debug(f"error deleting mailbox with id '{mailbox_id}': {result}")
             return result
 
-    def query_email(self, filter=None, limit=None):
+    def query_email(self, filter=None, limit=None, collapse_threads=True):
         """
         Perform an email query using the provided filter, and return the found email ids.
         """
         method = EmailQuery(
-            collapse_threads=True,
+            collapse_threads=collapse_threads,
             filter=filter,
             limit=limit,
         )
 
-        log.debug(f'querying email with filter: {filter} and limit: {limit}')
+        log.debug(f'querying email with filter: {filter}, limit: {limit}, collapse_threads: {collapse_threads}')
 
         try:
             result = self.client.request(method)
@@ -586,25 +586,33 @@ class JMAP:
         Check the inbox for a message to arrive with the given subject. If the message hasn't arrived yet wait
         for it; return the id of the message after it has arrived (or -1 if it never arrived).
         """
-        max_checks = 60
+        max_wait_seconds = 7 * 60
         wait_seconds = 5
+        max_checks = (max_wait_seconds // wait_seconds) + 1
         arrived_msg_id = 0
 
+        mailbox_search = self.get_mailbox_by_name('Inbox')
+        assert mailbox_search, 'expected to get the inbox mailbox'
+        inbox_id = mailbox_search[0].id
+        assert inbox_id, 'expected to get the inbox mailbox id'
+
         for checks in range(1, max_checks + 1):
+            if checks > 1:
+                time.sleep(wait_seconds)
+
             log.debug(
-                f'waiting {wait_seconds} seconds for message to arrive in test_acct_1 inbox '
-                f'(check {checks} of {max_checks})'
+                f'checking for message to arrive in {self.username.split("@")[0]} inbox {inbox_id} '
+                f'(check {checks} of {max_checks}, timeout {max_wait_seconds} seconds)'
             )
-            time.sleep(wait_seconds)
 
             search_filter = {
-                'inMailbox': 'a',
+                'inMailbox': inbox_id,
                 'subject': subject,
             }
 
-            found_email_ids = self.query_email(filter=search_filter)
+            found_email_ids = self.query_email(filter=search_filter, collapse_threads=False)
 
-            if len(found_email_ids) == 1:
+            if found_email_ids:
                 arrived_msg_id = found_email_ids[0]
                 break
 

--- a/test/integration/imap/test_messaging.py
+++ b/test/integration/imap/test_messaging.py
@@ -284,7 +284,7 @@ class TestIMAPMessaging:
         msg_subject = imap.fetch_message_details(test_msg)['Subject']
         log.debug(f'message to be deleted has this subject: {msg_subject}')
 
-        imap.delete_messages(test_msg)
+        imap.delete_messages([test_msg])
 
         # search for deleted message and verify still there; flag was already checked in delete_messages above
         found_msg = imap.search_messages('SUBJECT', msg_subject)
@@ -300,7 +300,7 @@ class TestIMAPMessaging:
         msg_subject = imap.fetch_message_details(test_msg)['Subject']
         log.debug(f'message to be deleted has this subject: {msg_subject}')
 
-        imap.delete_messages(test_msg)
+        imap.delete_messages([test_msg])
 
         # search for deleted message and verify still there; flag was already checked in delete_messages above
         found_msg = imap.search_messages('SUBJECT', msg_subject)


### PR DESCRIPTION
## What changed?
Fix some mailstrom intermittent integration test failures.

## Why?
The tests are mostly (98%) stable but would be nice to get rid of the intermittent failures.

## Limitations and Notes
Changes made by Codex AI; we will see how these changes prove out after a couple weeks in CI. More details:

Changes made so far:

- Fixed IMAP deletion test calls in [test_messaging.py](/Users/rwood/dev/mailstrom/test/integration/imap/test_messaging.py:287) and [test_messaging.py](/Users/rwood/dev/mailstrom/test/integration/imap/test_messaging.py:303) so single message ids are passed as lists to `imap.delete_messages()`. This prevents multi-digit ids like `"25"` from being iterated character-by-character.

- Hardened `IMAP.delete_messages()` in [IMAP.py](/Users/rwood/dev/mailstrom/test/common/IMAP.py:378) so it verifies `\Deleted` by fetching message flags after `STORE`, rather than depending on the exact shape of the `STORE` response data.

- Improved `JMAP.wait_for_message_to_arrive()` in [JMAP.py](/Users/rwood/dev/mailstrom/test/common/JMAP.py:584) to dynamically resolve the active account’s Inbox id, poll immediately, wait up to 7 minutes, accept one or more matching messages, and log the account/inbox being checked.

- Updated `JMAP.query_email()` in [JMAP.py](/Users/rwood/dev/mailstrom/test/common/JMAP.py:354) to make `collapse_threads` configurable, preserving the existing default while allowing arrival polling to query with `collapse_threads=False`. This should help self-send CC/BCC tests where collapsed thread results may hide the inbox copy.

## Applicable Issues
Fixes #230.

## QA Log
- Ran the integration tests on my machine against stage several times, and
- Ran the nightly mailstrom [integration tests GHA job](https://github.com/thunderbird/mailstrom/actions/runs/28476279009) against this branch in CI several times and didn't see any intermittent failures thus far.