### PR TITLE
Build redundant host for API calls

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -137,9 +137,22 @@ resources:
             - management
           storage_capacity: 20
           subnet: subnet-0b7564960babec972
+        "51":
+          disable_api_termination: True
+          function: 'api'
+          ignore_ami_changes: True
+          ignore_user_data_changes: True
+          instance_type: t3.micro
+          key_name: mailstrom-prod
+          node_roles:
+            - all
+          services:
+            - management
+          storage_capacity: 20
+          subnet: subnet-0b7564960babec972
 
       public_load_balancer:
-        excluded_nodes: [ "50" ]
+        excluded_nodes: [ "50", "51" ]
         services:
           https:
             source_cidrs: ['0.0.0.0/0']
@@ -158,7 +171,7 @@ resources:
 
       private_load_balancers:
         management:
-          excluded_nodes: ["0", "1"]
+          excluded_nodes: ["0", "1", "51"]
           source_security_group_ids:
             - sg-034b36952ac31b87b  # accounts-prod api container
             - sg-0ede6c1f9f8a4b676  # accounts-prod celery container


### PR DESCRIPTION
This PR builds a redundant node for handling Stalwart 0.15 API calls. However, it specifically **prevents** it from being added to a load balancer. This will give me opportunity to verify the server gets bootstrapped correctly and is ready to take traffic. I'll follow up with a later PR to add it into rotation.