### PR TITLE
Scale prod to use bigger instances

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -44,7 +44,7 @@ resources:
       peering_connections: {}
       additional_routes:
         private:
-          - destination_cidr_block: 10.10.0.0/16  # accounts-prod
+          - cidr_block: 10.10.0.0/16  # accounts-prod
             vpc_peering_connection_id: pcx-0fdcc9b776a069d2d
         public: []
 

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -88,12 +88,13 @@ resources:
             value: "yes"
         port: 6379
       nodes:
-        "0": # Must be a unique, stringified integer
+        # --- Mail nodes. 8 CPUs, 32 GB RAM, 4 nodes.
+        "10": # Must be a unique, stringified integer
           disable_api_termination: True
           function: 'mail'
           ignore_ami_changes: True
           ignore_user_data_changes: True
-          instance_type: t3a.large
+          instance_type: m7a.2xlarge
           key_name: mailstrom-prod
           node_roles:
             - all
@@ -106,12 +107,12 @@ resources:
             - smtps
             - submission
           storage_capacity: 20
-        "1": # Must be a unique, stringified integer
+        "11": # Must be a unique, stringified integer
           disable_api_termination: True
           function: 'mail'
           ignore_ami_changes: True
           ignore_user_data_changes: True
-          instance_type: t3a.large
+          instance_type: m7a.2xlarge
           key_name: mailstrom-prod
           node_roles:
             - all
@@ -124,12 +125,12 @@ resources:
             - smtps
             - submission
           storage_capacity: 20
-        "2": # Must be a unique, stringified integer
+        "12": # Must be a unique, stringified integer
           disable_api_termination: True
           function: 'mail'
           ignore_ami_changes: True
           ignore_user_data_changes: True
-          instance_type: t3a.large
+          instance_type: m7a.2xlarge
           key_name: mailstrom-prod
           node_roles:
             - all
@@ -142,12 +143,12 @@ resources:
             - smtps
             - submission
           storage_capacity: 20
-        "3": # Must be a unique, stringified integer
+        "13": # Must be a unique, stringified integer
           disable_api_termination: True
           function: 'mail'
           ignore_ami_changes: True
           ignore_user_data_changes: True
-          instance_type: t3a.large
+          instance_type: m7a.2xlarge
           key_name: mailstrom-prod
           node_roles:
             - all
@@ -160,35 +161,37 @@ resources:
             - smtps
             - submission
           storage_capacity: 20
-        "50":
+
+        # --- API nodes. 8 CPUs, 32 GB RAM, 2 nodes.
+        "60":
           disable_api_termination: True
           function: 'api'
           ignore_ami_changes: True
           ignore_user_data_changes: True
-          instance_type: t3.micro
+          instance_type: m7a.2xlarge
           key_name: mailstrom-prod
           node_roles:
             - all
           services:
             - management
           storage_capacity: 20
-          subnet: subnet-0b7564960babec972
-        "51":
+          subnet: subnet-054346d611223f189  # mailstrom-prod-vpc-private_subnet-0
+        "61":
           disable_api_termination: True
           function: 'api'
           ignore_ami_changes: True
           ignore_user_data_changes: True
-          instance_type: t3.micro
+          instance_type: m7a.2xlarge
           key_name: mailstrom-prod
           node_roles:
             - all
           services:
             - management
           storage_capacity: 20
-          subnet: subnet-0b7564960babec972
+          subnet: subnet-0b7564960babec972 # mailstrom-prod-vpc-private_subnet-1
 
       public_load_balancer:
-        excluded_nodes: [ "50", "51" ]
+        excluded_nodes: [ "60", "61" ]
         services:
           https:
             source_cidrs: ['0.0.0.0/0']
@@ -207,7 +210,7 @@ resources:
 
       private_load_balancers:
         management:
-          excluded_nodes: ["0", "1", "2", "3" ]
+          excluded_nodes: [ "10", "11", "12", "13" ]
           source_security_group_ids:
             - sg-034b36952ac31b87b  # accounts-prod api container
             - sg-0ede6c1f9f8a4b676  # accounts-prod celery container

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2>=3.1,<4.0
 pulumi_cloudflare==6.6.0
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.18
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@main
 toml>=0.10.2,<0.11


### PR DESCRIPTION
We keep putting more users on our servers (🥳), but this is raising load. Previously, I scaled out some extra nodes, but they were all t3.* instance types which are not ideal at all for production use. This PR replaces all of those nodes with a fresh, new set of m7a.2xlarge instances. This is a substantial increase in compute power that also removes the CPU credit metering we have to deal with in T-class instance types.

However, while carefully rolling these changes out, I ran a `pulumi refresh`, which brought to light a [bug that I have fixed in tb_pulumi](https://github.com/thunderbird/pulumi/pull/280). For this reason, I am pinning this to the `main` branch; I don't want to involve this code change in other environments.

These code changes have already been rolled out.