### PR TITLE
Apply the JMAP config block and raise the blob upload quota

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,3 +32,23 @@ jobs:
         uses: chartboost/ruff-action@v1
         with:
           src: "."
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    env:
+      IS_CI_AUTOMATION: "yes"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ."[dev]"
+
+      - name: Run unit tests
+        run: python -m pytest test/unit -v

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,10 +40,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # 3.13 to match the nightly workflow: tb_pulumi requires >=3.13, so
+      # installing the project on 3.12 fails to resolve.
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13.0"
 
       - name: Install dependencies
         run: |

--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -88,7 +88,7 @@ enable=true
 user="admin"
 secret="{{ fallback_admin_password }}"
 
-{% if jmap %}{{ jmap_toml }}{% endif -%}
+{% if jmap_toml %}{{ jmap_toml }}{% endif -%}
 {% if spam_filter %}{{ spam_filter_toml }}{% endif -%}
 {%- if 'management' in node_services or 'https' in node_services -%}
 [http]

--- a/pulumi/config.dev.yaml
+++ b/pulumi/config.dev.yaml
@@ -169,8 +169,8 @@ resources:
             max-concurrent: 4
             max-size: 50000000
             quota:
-              files: 1000
-              size: 50000000
+              files: 100000
+              size: 10000000000
             ttl: 1h
         push:
           attempts:

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -200,8 +200,8 @@ resources:
             max-concurrent: 4
             max-size: 50000000
             quota:
-              files: 1000
-              size: 50000000
+              files: 100000
+              size: 10000000000
             ttl: 1h
         push:
           attempts:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -200,8 +200,8 @@ resources:
             max-concurrent: 4
             max-size: 50000000
             quota:
-              files: 1000
-              size: 50000000
+              files: 100000
+              size: 10000000000
             ttl: 1h
         push:
           attempts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "ruff",
     "python-dotenv==1.0.1",
     "pytest==8.3.4",
+    "pyyaml==6.0.2",
     "locust==2.36.2",
     "jmapc==0.2.23",
     "caldav==2.2.6",

--- a/test/unit/test_bootstrap_template.py
+++ b/test/unit/test_bootstrap_template.py
@@ -1,0 +1,110 @@
+"""Guards that stalwart.toml.j2 only uses variables the bootstrap actually supplies.
+
+The JMAP block was gated on `{% if jmap %}` while bootstrap.py only ever defines
+`jmap_toml`. Jinja renders an undefined name as falsy without raising, so the whole
+block was silently dropped from every node's config.toml and Stalwart ran on its
+compiled-in JMAP defaults instead.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+import toml
+import yaml
+from jinja2 import Environment, FileSystemLoader, nodes
+from jinja2.meta import find_undeclared_variables
+
+REPO = Path(__file__).resolve().parents[2]
+TEMPLATES = REPO / 'pulumi/bootstrap/templates'
+BOOTSTRAP = REPO / 'pulumi/bootstrap/bootstrap.py'
+TEMPLATE = 'stalwart.toml.j2'
+
+# `spam_filter` guards `spam_filter_toml` and has exactly the same defect the jmap gate
+# had. Correcting it activates a spam-filter config that has never run in production, so
+# it needs reviewing on its own rather than riding along with an unrelated change.
+KNOWN_UNDEFINED = {'spam_filter'}
+
+# Stand-ins for the secret payloads, only detailed enough for the template to render.
+STUB_SECRETS = {
+    'keycloak_backend': {
+        'auth_method': 'basic',
+        'auth_username': 'u',
+        'auth_secret': 's',
+        'endpoint_method': 'introspect',
+        'endpoint_url': 'https://example.test/introspect',
+        'fields_email': 'username',
+        'timeout': '15s',
+    },
+    'postgresql_backend': {'host': 'db.test', 'database': 'stalwart', 'user': 'u', 'password': 'p'},
+    's3_backend': {'bucket': 'b', 'region': 'eu-central-1'},
+    'redis_backend': {'timeout': '15s'},
+}
+STUB_TAGS = {
+    'node_id': 10,
+    'node_services': 'https,imaps,lmtp,managesieve,smtp,smtps,submission',
+    'node_roles': 'all',
+    'https_paths': '/jmap,/.well-known/jmap',
+    'stalwart_image': 'stalwartlabs/stalwart:v0.15.4',
+}
+
+
+def _declaration(name: str):
+    """Read a literal assignment out of bootstrap.py.
+
+    It cannot be imported: at module scope it points logging.basicConfig at
+    /var/log/stalwart-bootstrap.log, which is not writable off a node.
+    """
+    tree = ast.parse(BOOTSTRAP.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(getattr(t, 'id', None) == name for t in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f'no literal assignment to {name} in {BOOTSTRAP}')
+
+
+@pytest.fixture(scope='module')
+def provided() -> set[str]:
+    """Every name bootstrap.py puts into the Jinja context."""
+    return set(_declaration('TEMPLATE_VALUE_TAG_MAP')) | set(_declaration('secret_names'))
+
+
+@pytest.fixture(scope='module')
+def env() -> Environment:
+    return Environment(loader=FileSystemLoader(TEMPLATES))
+
+
+def test_template_only_references_variables_bootstrap_provides(env, provided):
+    source = (TEMPLATES / TEMPLATE).read_text()
+    # Names the template sets itself, plus those inherited from ports.j2 via extends.
+    local = {
+        assign.target.name
+        for path in TEMPLATES.iterdir()
+        for assign in env.parse(path.read_text()).find_all(nodes.Assign)
+    }
+
+    missing = find_undeclared_variables(env.parse(source)) - provided - local
+
+    assert missing == KNOWN_UNDEFINED, (
+        f'{TEMPLATE} references {sorted(missing)}; bootstrap.py defines {sorted(provided)}. '
+        f'Jinja treats an undefined name as falsy/empty instead of failing, so any config it '
+        f'guards is silently dropped. Add the variable to bootstrap.py or correct the '
+        f'reference -- and if you fixed one of {sorted(KNOWN_UNDEFINED)}, drop it from '
+        f'KNOWN_UNDEFINED.'
+    )
+
+
+@pytest.mark.parametrize('stack', ['prod', 'stage', 'dev'])
+def test_jmap_config_reaches_the_rendered_config_toml(env, provided, stack):
+    cluster = yaml.safe_load((REPO / f'pulumi/config.{stack}.yaml').read_text())
+    jmap = next(iter(cluster['resources']['tb:mailstrom:StalwartCluster'].values()))['jmap']
+
+    context = {name: '' for name in provided} | STUB_TAGS | STUB_SECRETS
+    # Built exactly as the Pulumi program builds the secret it stores for the nodes.
+    context['jmap_toml'] = toml.dumps({'jmap': jmap})
+
+    rendered = env.get_template(TEMPLATE).render(**context)
+
+    assert '[jmap.protocol.upload.quota]' in rendered, (
+        f'the {stack} jmap config never reached config.toml; Stalwart would fall back to '
+        f'its built-in defaults, including a 1000 file / 50 MB hourly blob upload quota'
+    )


### PR DESCRIPTION
## Summary

Two changes, one of which is a latent bug fix that the other depends on.

**1. The JMAP config block is not applied on any node.** `stalwart.toml.j2` gated the section on a `jmap` variable, but `bootstrap.py` only ever defines `jmap_toml` (from `mailstrom/<env>/stalwart.postboot.jmap_toml`). Jinja's undefined is falsy, so the block renders as nothing — silently, with no error in `/var/log/stalwart-bootstrap.log`. Every node is running Stalwart's compiled-in JMAP defaults instead, and the `jmap_toml` secret goes unread.

Audited all eight nodes:

| | prod (6 nodes) | stage (2 nodes) |
|---|---|---|
| `[jmap]` keys in `config.toml` | 0 on every node | 0 on both |
| on-disk bootstrap template gate | `{% if jmap %}` on every node | `{% if jmap %}` on both |
| `config.toml` last rendered | 2026-07-21 | 2026-07-27 |

So the broken template ran on every node within the last week; this isn't stale state from an old boot. `main` has carried `{% if jmap %}` continuously since it was introduced in f45eefe (2025-04-21), and abd3374b (2025-05-21) rewrote the surrounding lines while keeping it, so no `bootstrap.tbz` built from `main` could have rendered the block. The secret itself exists and was last written 2025-04-28.

Note for reviewers: the identical one-word fix already exists on the unmerged `add-archives-folder` branch (2c68c8f, 2025-10-16). Whoever picks that branch back up should expect a conflict here, or drop its version of this line.

**2. Raise the blob upload quota** from 1000 files / 50 MB per hour to 100000 files / 10 GB, in all three environments.

The default is enforced per account on `POST /jmap/upload`, `Blob/upload` and `Blob/copy`. At 1000 files/hour a bulk mailbox import over JMAP dies after the first ~1000 messages, and 50 MB/hour is reachable by a webmail user sending a few large attachments — our own client uploads inline images and attachments through that endpoint. On v0.15.4 the rejection is an HTTP 403 with a `Quota exceeded` problem-detail, which clients tend to misreport as an auth failure.

The new numbers put the quota above the constraint that binds first anyway: `http.rate-limit.account` defaults to 1000 requests/minute, and a JMAP importer spends 2 requests per message, so throughput is capped near 30k messages/hour regardless. `upload.ttl` stays at 1h and `upload.max-size` stays at 50 MB, so a single upload is still bounded and temporary blobs still expire — the guard against parking unowned data survives, just at a workable scale.

## Reviewer notes

Because `jmap.*` is in `config.local-keys`, these settings are read from each node's local `config.toml`, not the config store. The settings management API can't be used for them, and `/api/reload` won't pick them up.

**Activating the block is close to a no-op besides the quota**, which I checked key by key against Stalwart v0.15.4. Most values are verbatim copies of the defaults, and several are under prefixes Stalwart doesn't read:

| we render | v0.15.4 reads |
|---|---|
| `jmap.email.auto-expunge` | `email.auto-expunge` |
| `jmap.protocol.changes.max-history` | `changes.max-history` (a count, not a duration) |
| `jmap.protocol.email.max-size`, `.max-attachment-size` | `jmap.email.max-size`, `jmap.email.max-attachment-size` |
| `jmap.protocol.mailbox.max-depth`, `.max-name-length` | `jmap.mailbox.*` |
| `jmap.protocol.parse.max-items` | `jmap.email.parse.max-items` |
| `jmap.rate-limit.account`, `.anonymous` | `http.rate-limit.account`, `.anonymous` |
| `jmap.websocket.*` | `jmap.web-socket.*` |
| `jmap.account.purge.frequency` | `account.purge.frequency` |
| `jmap.push.max-total` | not read at all |

All of those are set to the same value as the default, so behaviour is unchanged, but they aren't doing what the file implies. Worth a follow-up to correct the prefixes deliberately rather than bundling it here.

One deliberate behaviour change rides along: `jmap.push.throttle` is `1ms` against a 1s default and *is* correctly prefixed, so this PR makes it live. It's the coalescing window between outbound `StateChange` deliveries to a `PushSubscription` endpoint, so at 1ms there's effectively no batching. It doesn't touch the webmail path, which uses EventSource/WebSocket with separate throttles that match the defaults. Keeping the authored value.

The `spam_filter` gate on the following line has the identical bug and is deliberately untouched — activating the spam filter config needs its own review.

## Regression test

`test/unit/test_bootstrap_template.py` renders `stalwart.toml.j2` with only the names `bootstrap.py` actually puts in the Jinja context, and fails if the template references anything else. That is the general form of this defect: Jinja resolves an undefined name to a falsy `Undefined` rather than raising, so a mistyped guard silently discards whatever it wraps. Reverting the gate to `{% if jmap %}` fails all four cases.

It also flags the identical defect in the `spam_filter` guard on the next line, recorded in `KNOWN_UNDEFINED` with a comment — fixing that one activates a spam-filter config that has never run in production, so it wants its own PR rather than riding along here.

`bootstrap.py` can't be imported for this (at module scope it points `logging.basicConfig` at `/var/log/stalwart-bootstrap.log`), so its declarations are read with `ast`, which also means the test tracks the real lists rather than a copy of them.

The unit tests are wired into the `validate` workflow, which previously ran only ruff. The nightly workflow runs just the per-protocol integration dirs, so nothing would otherwise execute them. `pyyaml` is added to the dev extras since the test imports it and it was only present transitively.

## Test plan

- [x] `pytest test/unit` passes; reverting the one-word gate change fails all four cases.
- [x] Rendered against the real `config.prod.yaml`: `[jmap.protocol.upload.quota]` appears with `files = 100000`, `size = 10000000000`, `ttl` and `max-size` unchanged.
- [ ] Deploy to stage, stop/start its nodes, confirm `[jmap]` appears in `/opt/stalwart/etc/config.toml` and that the server starts cleanly with no unknown-key warnings.
- [ ] On stage, confirm a bulk JMAP import runs past 1000 messages without a 403.
- [ ] Then prod, one node at a time.

## Rollout warning

The template ships inside the instance user data (base64 `bootstrap.tbz` in `stalwart_instance_user_data.sh.j2`), and nodes are built with `ignore_user_data_changes: True`. `pulumi up` will **not** apply this to running instances — each node must be stopped and started (not rebooted) to re-run bootstrap and re-render `config.toml`. That's 2 nodes on stage and 6 on prod.
