### PR TITLE
Fix the bootstrap template to look for the right variable

### DIFF
--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -89,7 +89,7 @@ user="admin"
 secret="{{ fallback_admin_password }}"
 
 {% if jmap_toml %}{{ jmap_toml }}{% endif -%}
-{% if spam_filter %}{{ spam_filter_toml }}{% endif -%}
+{% if spam_filter_toml %}{{ spam_filter_toml }}{% endif -%}
 {%- if 'management' in node_services or 'https' in node_services -%}
 [http]
 allowed-endpoint=

--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -88,7 +88,7 @@ enable=true
 user="admin"
 secret="{{ fallback_admin_password }}"
 
-{% if jmap %}{{ jmap_toml }}{% endif -%}
+{% if jmap_toml %}{{ jmap_toml }}{% endif -%}
 {% if spam_filter %}{{ spam_filter_toml }}{% endif -%}
 {%- if 'management' in node_services or 'https' in node_services -%}
 [http]


### PR DESCRIPTION
I fixed the name of a variable. Having the wrong variable in this template prevented this section from ever appearing in our Stalwart configs. I tested this in stage and it generated the correct config section.