### PR TITLE
Use cidr_block for stage's peering route

### DIFF
--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -42,7 +42,7 @@ resources:
       peering_connections: {}
       additional_routes:
         private:
-          - destination_cidr_block: 10.11.0.0/16  # accounts-stage
+          - cidr_block: 10.11.0.0/16  # accounts-stage
             vpc_peering_connection_id: pcx-063f07eca0677a761
         public: []
 


### PR DESCRIPTION
`additional_routes` entries are folded into the route table's inline routes, which take `cidr_block`. Stage used `destination_cidr_block`, so the program raised `TypeError: Route._internal_init() got an unexpected keyword argument` and built nothing. Prod was already correct.

Already applied to the stage stack.