### PR TITLE
Accept peering request from tb-dev

### DIFF
--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -40,10 +40,19 @@ resources:
       endpoint_interfaces:
         - secretsmanager
       peering_connections: {}
+      peering_accepters:
+        mzla-tb-dev:
+          vpc_peering_connection_id: pcx-0ccde8cf3779401b9
+          accepter:
+            allow_remote_vpc_dns_resolution: True
+          auto_accept: True
+
       additional_routes:
         private:
-          - destination_cidr_block: 10.11.0.0/16  # accounts-stage
+          - cidr_block: 10.11.0.0/16  # accounts-stage
             vpc_peering_connection_id: pcx-063f07eca0677a761
+          - cidr_block: 10.120.0.0/16  # tb-dev
+            vpc_peering_connection_id: pcx-0ccde8cf3779401b9
         public: []
 
   tb:ec2:SshableInstance:
@@ -85,24 +94,6 @@ resources:
         port: 6379
 
       nodes:
-        # "0": # Must be a unique, stringified integer
-        #   disable_api_termination: True
-        #   ignore_ami_changes: True
-        #   ignore_user_data_changes: True
-        #   instance_type: t3a.large
-        #   key_name: mailstrom-stage
-        #   node_roles:
-        #     - all
-        #   services:
-        #     - https
-        #     - imaps
-        #     - lmtp
-        #     - managesieve
-        #     - smtp
-        #     - smtps
-        #     - submission
-        #   storage_capacity: 20
-        #   subnet: subnet-07ade1ed35462907d  # eu-central-1a
         "1":
           disable_api_termination: True
           function: 'mail'


### PR DESCRIPTION
In order for the Stalwart-provided migration instructions to work, we need a fully private route from the migration proxy to the legacy-stage deployment. In order to accomplish this, we have to have these networks peered. This is the acceptor side of the peering, in which we accept the peering request made by [this PR](https://github.com/thunderbird/platform-infrastructure/pull/858) and establish the reverse route back into that VPC.

I have already applied these changes (had to in order to get a peering connection ID). It's important to note that the peering connection has a different ID in each VPC.