### PR TITLE
Use special configs when operating behind SMP

### DIFF
--- a/pulumi/bootstrap/bootstrap.py
+++ b/pulumi/bootstrap/bootstrap.py
@@ -21,6 +21,7 @@ TEMPLATE_MAP = {
 }
 # Map of template variable to EC2 tags
 TEMPLATE_VALUE_TAG_MAP = {
+    'behind_proxy': 'postboot.stalwart.behind_proxy',
     'env': 'environment',
     'function': 'postboot.stalwart.function',
     'https_paths': 'postboot.stalwart.https_paths',

--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -27,9 +27,9 @@ protocol="{{ service_ports[service]['protocol'] }}"
 {%-   if service in ['https', 'imaps', 'jmap', 'management', 'managesieve', 'pop3s', 'smtps'] %}
 tls.implicit=true
 {%-   endif %}
-{%-   if behind_proxy == 'true' and service in ['imaptls', 'submission', 'submissions', 'sieve', 'https'] %}
+{%-   if behind_proxy == 'true' and service_ports[service]['listener'] in ['imaptls', 'submission', 'submissions', 'sieve', 'https'] %}
 proxy.override=true
-proxy.trusted-networks=['10.120.192.0/23', '10.120.194.0/23']
+proxy.trusted-networks={{ "['10.120.192.0/23', '10.120.194.0/23']" if env == 'stage' else "['10.130.192.0/23', '10.130.194.0/23']" }}
 {%-   endif %}
 {% endfor %}
 [storage]
@@ -109,7 +109,7 @@ spf.verify.mail-from = "disable"
 
 [queue.route.smarthost]
 type = "relay"
-address = "smtp-relay.stage-thundermail.com"
+address = {{ "smtp-relay.stage-thundermail.com" if env == 'stage' else "smtp-relay.thundermail.com" }}
 port = 25,
 protocol = "smtp"
 tls.implicit = false

--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -110,15 +110,15 @@ spf.verify.mail-from = "disable"
 [queue.route.smarthost]
 type = "relay"
 address = {{ "smtp-relay.stage-thundermail.com" if env == 'stage' else "smtp-relay.thundermail.com" }}
-port = 25,
+port = 25
 protocol = "smtp"
 tls.implicit = false
 tls.allow-invalid-certs = true
 
-[queue.strategy.route] = [
-    {"if": "is_local_domain('*', rcpt_domain)"},
-    {"then": "'local'"},
-    {"else": "'smarthost'"}
+[queue.strategy]
+route = [
+    {if="is_local_domain('*', rcpt_domain)",then="'local'"},
+    {else="'smarthost'"}
 ]
 {% endif %}
 

--- a/pulumi/bootstrap/templates/stalwart.toml.j2
+++ b/pulumi/bootstrap/templates/stalwart.toml.j2
@@ -6,7 +6,11 @@ local-keys = [ "store.*", "directory.*", "tracer.*", "server.listener.*",
                "authentication.fallback-admin.*", "!cluster.key", "cluster.*",
                "config.local-keys.*", "storage.data", "storage.blob",
                "storage.lookup", "storage.fts", "storage.directory",
-               "http.allowed-endpoint", "http.allowed-endpoint.*" ]
+               "http.allowed-endpoint", "http.allowed-endpoint.*",
+{%- if behind_proxy == 'true' %}
+               "auth.*", "queue.route.smarthost*", "queue.strategy.*",
+{%- endif %}
+]
 
 [cluster]
 node-id={{ node_id }}
@@ -22,6 +26,10 @@ bind=["[::]:{{ service_ports[service]['port'] }}"]
 protocol="{{ service_ports[service]['protocol'] }}"
 {%-   if service in ['https', 'imaps', 'jmap', 'management', 'managesieve', 'pop3s', 'smtps'] %}
 tls.implicit=true
+{%-   endif %}
+{%-   if behind_proxy == 'true' and service in ['imaptls', 'submission', 'submissions', 'sieve', 'https'] %}
+proxy.override=true
+proxy.trusted-networks=['10.120.192.0/23', '10.120.194.0/23']
 {%-   endif %}
 {% endfor %}
 [storage]
@@ -87,6 +95,32 @@ enable=true
 [authentication.fallback-admin]
 user="admin"
 secret="{{ fallback_admin_password }}"
+
+{# We need these settings when behind a proxy. When not, they appear to simply not be set, rather
+   than being set to some specific value. #}
+{%- if behind_proxy == 'true' %}
+[auth]
+arc.verify = "disable"
+dkim.verify = "disable"
+dmarc.verify = "disable"
+iprev.verify = "disable"
+spf.verify.ehlo = "disable"
+spf.verify.mail-from = "disable"
+
+[queue.route.smarthost]
+type = "relay"
+address = "smtp-relay.stage-thundermail.com"
+port = 25,
+protocol = "smtp"
+tls.implicit = false
+tls.allow-invalid-certs = true
+
+[queue.strategy.route] = [
+    {"if": "is_local_domain('*', rcpt_domain)"},
+    {"then": "'local'"},
+    {"else": "'smarthost'"}
+]
+{% endif %}
 
 {% if 'management' in node_services or 'https' in node_services -%}
 [http]

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -67,6 +67,7 @@ resources:
   #       - your.ip.addr.ess/32
 
   tb:mailstrom:StalwartCluster:
+    behind_proxy: false
     thundermail:
       https_features:
         - caldav

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -71,6 +71,7 @@ resources:
 
   tb:mailstrom:StalwartCluster:
     thundermail:
+      behind_proxy: false
       https_features:
         - caldav
         - carddav

--- a/pulumi/stalwart/__init__.py
+++ b/pulumi/stalwart/__init__.py
@@ -121,6 +121,10 @@ class StalwartCluster(tb_pulumi.ThunderbirdComponentResource):
         in which to build cluster nodes.
     :type subnets: list[aws.ec2.Subnet]
 
+    :param behind_proxy: Whether the servers should operate as though they are running behind a Stalwart Migration
+        Proxy. This changes a tag on certain instances which then affects bootstrapping behavior. Defaults to False.
+    :type behind_proxy: bool
+
     :param https_features: List of features which Stalwart presents over the https service to enable across the cluster.
         These must match with keys in the HTTPS_FEATURES dict. Defaults to [].
     :type https_features: dict, optional
@@ -254,6 +258,7 @@ class StalwartCluster(tb_pulumi.ThunderbirdComponentResource):
         log_group_arn: str,
         private_subnets: list[aws.ec2.Subnet],
         public_subnets: list[aws.ec2.Subnet],
+        behind_proxy: bool = False,
         https_features: list = [],
         nodes: dict = {},
         node_additional_ingress_rules: list[dict] = [],
@@ -282,6 +287,7 @@ class StalwartCluster(tb_pulumi.ThunderbirdComponentResource):
             raise ValueError('You must provide at least one pubic subnet.')
 
         # Internalize some vars we need in the other functions and properties
+        self.behind_proxy = behind_proxy
         self.https_features = https_features
         self.nodes = nodes
         self.private_load_balancers = private_load_balancers
@@ -712,6 +718,7 @@ class StalwartCluster(tb_pulumi.ThunderbirdComponentResource):
         # These tags will later get read back when the instance comes online by the postboot process
         postboot_tags = {
             'postboot.stalwart.aws_region': self.project.aws_region,
+            'postboot.stalwart.behind_proxy': 'true' if self.behind_proxy else 'false',
             'postboot.stalwart.env': self.project.stack,
             'postboot.stalwart.function': function,
             'postboot.stalwart.https_paths': ','.join(https_paths),


### PR DESCRIPTION
We currently operate in what the Stalwart docs refer to as "standalone mode". That is, our installation operates directly, without a proxy in front of it. However, we need to be able to place our legacy installations behind a migration proxy, which requires several significant settings alterations. We also want to be able to roll back easily if something fails.

Therefore, I am introducing here a new option, `behind_proxy`, which makes these settings changes in our bootstrapped/templated config files. We can swap this from `false` to `true` in our Pulumi configs, then roll out the changes when we're ready. If we need to roll back, we can swap it back to `false` and the changes will be rolled back when bootstrapping is run again.